### PR TITLE
Fix session types

### DIFF
--- a/types/components/Session.d.ts
+++ b/types/components/Session.d.ts
@@ -1,6 +1,17 @@
-interface SessionData {
-    [key: string]: any;
-}
+/**
+ * This interface allows you to declare additional properties on your session object using [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html).
+ *
+ * @example
+ * import 'hyper-express-session/types/components/Session';
+ * 
+ * declare module 'hyper-express-session/types/components/Session' {
+ *     interface SessionData {
+ *         views: number;
+ *     }
+ * }
+ *
+ */
+export interface SessionData {};
 
 export default class Session {
     /* Session Methods */
@@ -78,13 +89,9 @@ export default class Session {
      * This method is used to set one or multiple session data values.
      * You may provide a name and value argument to update a single value.
      * You may provide an Object of keys/values to update multiple values in one operation.
-     *
-     * @param {String} name
-     * @param {Any} value
-     * @returns {Session} Session (Chainable)
      */
-    set(name: string, value: any): Session;
-    set(values: SessionData): Session;
+    set<T extends keyof SessionData>(name: T, value: SessionData[T]): Session;
+    set(sessionData: SessionData): Session;
 
     /**
      * This method replaces current session data values with provided data values object.
@@ -101,7 +108,7 @@ export default class Session {
      * @param {String=} name Optional
      * @returns {Any|Object|undefined}
      */
-    get(name: string): any | void;
+    get<T extends keyof SessionData>(name: T): SessionData[T];
     get(): SessionData;
 
     /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,2 +1,15 @@
 import SessionEngine from "./components/SessionEngine";
 export default SessionEngine;
+
+import Session from 'hyper-express-session/types/components/Session';
+
+declare module 'hyper-express' {
+    interface Request {
+        session: Session
+    }
+
+    interface Router {
+        use(sessionMiddleware: Function): void;
+        use(pattern: string, sessionMiddleware: Function): void;
+    }
+}


### PR DESCRIPTION
This should result in `request.session` being typed correctly.

Closes #6 